### PR TITLE
Fix calcs

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
             <tbody>
                 <tr>
                     <td>Dinner</td>
-                    <td>{{dinner}} €</td>
+                    <td>{{ dinner }} €</td>
                     <td>
                         <div class="list-buttons">
                             <button @click="increment('dinner')" class="list-buttons__item button button--add">+</button>
@@ -23,7 +23,7 @@
                 </tr>
                 <tr>
                     <td>Tip</td>
-                    <td>{{tip}} %</td>
+                    <td>{{ tip }} %</td>
                     <td>
                         <div class="list-buttons">
                             <button @click="increment('tip')" class="list-buttons__item button button--add">+</button>
@@ -33,7 +33,7 @@
                 </tr>
                 <tr>
                     <td>People</td>
-                    <td>{{people}}</td>
+                    <td>{{ people }}</td>
                     <td>
                         <div class="list-buttons">
                             <button @click="increment('people')" class="list-buttons__item button button--add">+</button>
@@ -43,17 +43,17 @@
                 </tr>
                 <tr class="total">
                     <td>Total with taxes (21%)</td>
-                    <td>{{ totalTaxes() }} €</td>
+                    <td>{{ totalTaxes().toFixed(2) }} €</td>
                     <td class="formula">( ( taxes * dinner ) / 100 ) + dinner</td>
                 </tr>
                 <tr class="total">
                     <td>Total with tip</td>
-                    <td>{{ totalTip() }} €</td>
+                    <td>{{ totalTip().toFixed(2) }} €</td>
                     <td class="formula">Total with taxes + Total with tip</td>
                 </tr>
                 <tr class="total">
                     <td>Total per person</td>
-                    <td>{{ totalPerson() }} €</td>
+                    <td>{{ totalPerson().toFixed(2) }} €</td>
                     <td class="formula">( Total with taxes + Total with tip ) * person</td>
                 </tr>
             </tbody>

--- a/js/app.js
+++ b/js/app.js
@@ -16,24 +16,22 @@ const app = new Vue({
             }
         },
         totalTaxes() {
-            let totalTaxes = ((this.taxes * this.dinner) / 100) + this.dinner;
-            let result = totalTaxes;
+            const totalWithTaxes = (this.taxes * this.dinner) / 100) + this.dinner;
             
-            return result.toFixed(2);
+            return totalWithTaxes.toFixed(2);
         },
         totalTip() {
-            let totalTaxes = ((this.taxes * this.dinner) / 100) + this.dinner;
-            let totalTip = ((this.tip * this.dinner) / 100) + this.dinner;
-            let result = totalTaxes + totalTip;
+            const totalWithTaxes = (this.taxes * this.dinner) / 100) + this.dinner;
+            const totalWithTip = totalWithTaxes * this.tip;
             
-            return result.toFixed(2);
+            return totalWithTip.toFixed(2);
         },
         totalPerson() {
-            let totalTaxes = ((this.taxes * this.dinner) / 100) + this.dinner;
-            let totalTip = ((this.tip * this.dinner) / 100) + this.dinner;
-            let result = (totalTaxes + totalTip) / this.people;
+            const totalWithTaxes = (this.taxes * this.dinner) / 100) + this.dinner;
+            const totalWithTip = totalWithTaxes * this.tip;
+            let perPerson = totalWithTip / this.people;
             
-            return result.toFixed(2);
+            return perPerson.toFixed(2);
         }
     },
 });

--- a/js/app.js
+++ b/js/app.js
@@ -11,25 +11,28 @@ const app = new Vue({
             this[key]++;
         },
         decrement(key) {
-            if(this[key] > 1 ) {
+            if (this[key] > 1 ) {
                 this[key]--; 
             }
         },
         totalTaxes() {
             let totalTaxes = ((this.taxes * this.dinner) / 100) + this.dinner;
             let result = totalTaxes;
+            
             return result.toFixed(2);
         },
         totalTip() {
             let totalTaxes = ((this.taxes * this.dinner) / 100) + this.dinner;
             let totalTip = ((this.tip * this.dinner) / 100) + this.dinner;
             let result = totalTaxes + totalTip;
+            
             return result.toFixed(2);
         },
         totalPerson() {
             let totalTaxes = ((this.taxes * this.dinner) / 100) + this.dinner;
             let totalTip = ((this.tip * this.dinner) / 100) + this.dinner;
-            let result = (totalTaxes + totalTip) * this.people;
+            let result = (totalTaxes + totalTip) / this.people;
+            
             return result.toFixed(2);
         }
     },

--- a/js/app.js
+++ b/js/app.js
@@ -16,20 +16,17 @@ const app = new Vue({
             }
         },
         totalTaxes() {
-            const totalWithTaxes = (this.taxes * this.dinner) / 100) + this.dinner;
+            const totalWithTaxes = this.dinner * (1 + this.taxes);
             
             return totalWithTaxes.toFixed(2);
         },
         totalTip() {
-            const totalWithTaxes = (this.taxes * this.dinner) / 100) + this.dinner;
-            const totalWithTip = totalWithTaxes * this.tip;
+            const totalWithTip = this.totalTaxes() * (1 + this.tip);
             
             return totalWithTip.toFixed(2);
         },
         totalPerson() {
-            const totalWithTaxes = (this.taxes * this.dinner) / 100) + this.dinner;
-            const totalWithTip = totalWithTaxes * this.tip;
-            let perPerson = totalWithTip / this.people;
+            const perPerson = this.totalTip() / this.people;
             
             return perPerson.toFixed(2);
         }

--- a/js/app.js
+++ b/js/app.js
@@ -11,24 +11,18 @@ const app = new Vue({
             this[key]++;
         },
         decrement(key) {
-            if (this[key] > 1 ) {
-                this[key]--; 
+            if (this[key] > 1) {
+                this[key]--;
             }
         },
         totalTaxes() {
-            const totalWithTaxes = this.dinner * (1 + this.taxes);
-            
-            return totalWithTaxes.toFixed(2);
+            return this.dinner * (1 + this.taxes / 100);
         },
         totalTip() {
-            const totalWithTip = this.totalTaxes() * (1 + this.tip);
-            
-            return totalWithTip.toFixed(2);
+            return this.totalTaxes() * (1 + this.tip / 100);
         },
         totalPerson() {
-            const perPerson = this.totalTip() / this.people;
-            
-            return perPerson.toFixed(2);
+            return this.totalTip() / this.people;
         }
     },
 });


### PR DESCRIPTION
Here's the problem.
<img width="832" alt="Screen Shot 2021-06-30 at 5 33 05 pm" src="https://user-images.githubusercontent.com/18750745/123989513-41c4c300-d9c9-11eb-928e-9026a5336c80.png">


The tip amount was almost double the taxes amount. So I updated that.

The person cal was multiplying instead of dividing - so more people made a _higher_ cost per person.

Also made the calcs _much_ simpler using `value * (1 + rate)` instead of `value + value * rate`

